### PR TITLE
Have serde serialization match strum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.0.0
+
+- Changes the Serde serialization of `Kind` to match Strum's.
 
 # v2.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fingerprint"
-version = "2.1.0"
+version = "3.0.0"
 edition = "2021"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub enum Kind {
     /// generally require specific circumstances: `CommentStrippedSHA256` requires that the file is text, and
     /// hypothetical future fingerprint kinds such as something based on an AST would require that the file is source code.
     #[strum(serialize = "sha_256")]
+    #[serde(rename = "sha_256")]
     RawSha256,
 
     /// Represents a fingerprint derived by hashing the contents of a file with the SHA256 algorithm
@@ -113,6 +114,7 @@ pub enum Kind {
     /// - Any sequence of multiple contiguous `\n` bytes are collapsed to a single `\n` byte.
     /// - The final `\n` byte is removed from the end of the stream if present.
     #[strum(serialize = "comment_stripped:sha_256")]
+    #[serde(rename = "comment_stripped:sha_256")]
     CommentStrippedSha256,
 
     /// Represents a fingerprint derived by hashing the raw contents of a JAR file with the SHA256 algorithm
@@ -123,6 +125,7 @@ pub enum Kind {
     /// - All the contents of these files are then hashed using SHA256.
     /// - If the contents of the files are text, `\r\n` sequences are converted to `\n`.
     #[strum(serialize = "v1.raw.jar")]
+    #[serde(rename = "v1.raw.jar")]
     JarRawV1,
 
     /// Represents a fingerprint derived by hashing the raw contents of a JAR file in the same manner
@@ -132,6 +135,7 @@ pub enum Kind {
     /// Specifically:
     /// - The content of the JAR file is hashed as-is using the sha1 algorithm.
     #[strum(serialize = "v1.mavencentral.jar")]
+    #[serde(rename = "v1.mavencentral.jar")]
     JarMavenCentralV1,
 
     /// Represents a fingerprint derived by hashing the raw contents of a JAR file with the SHA256 algorithm
@@ -142,6 +146,7 @@ pub enum Kind {
     /// - All the contents of these files are then hashed using SHA256.
     /// - If the contents of the files are text, `\r\n` sequences are converted to `\n`.
     #[strum(serialize = "v1.class.jar")]
+    #[serde(rename = "v1.class.jar")]
     JarClassV1,
 }
 

--- a/tests/it/code_vsi.rs
+++ b/tests/it/code_vsi.rs
@@ -162,7 +162,8 @@ fn serde_serialization_matches_external_contract() {
         let json_value = serde_json::to_value(kind).expect("serde serialization");
         let json = json_value.as_str().expect("get string").to_string();
 
-        actual_serializations_for_kinds.insert(json);
+        // Check that the insert wasn't a duplicate.
+        assert!(actual_serializations_for_kinds.insert(json));
     }
 
     assert_eq!(

--- a/tests/it/code_vsi.rs
+++ b/tests/it/code_vsi.rs
@@ -145,7 +145,7 @@ fn strum_serde_fingerprint_kind_serialization_matches() {
 
 #[test]
 fn serde_serialization_matches_external_contract() {
-    let mut serialized_strings = vec![
+    let expected_serializations_for_kinds = vec![
         "v1.class.jar",
         "v1.mavencentral.jar",
         "v1.raw.jar",
@@ -153,14 +153,20 @@ fn serde_serialization_matches_external_contract() {
         "sha_256",
     ]
     .into_iter()
-    .collect::<HashSet<&str>>();
+    .map(|s| s.to_string())
+    .collect::<HashSet<String>>();
+
+    let mut actual_serializations_for_kinds = HashSet::new();
 
     for kind in Kind::iter() {
         let json_value = serde_json::to_value(kind).expect("serde serialization");
-        let json = json_value.as_str().expect("get string");
+        let json = json_value.as_str().expect("get string").to_string();
 
-        serialized_strings.remove(json);
+        actual_serializations_for_kinds.insert(json);
     }
 
-    assert_eq!(serialized_strings, HashSet::new());
+    assert_eq!(
+        expected_serializations_for_kinds,
+        actual_serializations_for_kinds
+    );
 }

--- a/tests/it/code_vsi.rs
+++ b/tests/it/code_vsi.rs
@@ -1,8 +1,11 @@
 //! Tests for plain code files using legacy VSI fingerprints.
 
+use std::collections::HashSet;
+
 use pretty_assertions::assert_eq;
 
 use fingerprint::*;
+use strum::IntoEnumIterator;
 
 /// Assert fingerprint for the named kind is the same as the fingerprint for the provided content.
 /// Comparison content (the "expected" fingerprint) is generated with [`hash`].
@@ -127,4 +130,37 @@ int main() {
             .expect("decode hex literal"),
     );
     assert_eq!(Some(&expected), combined.get(Kind::CommentStrippedSha256));
+}
+
+#[test]
+fn strum_serde_fingerprint_kind_serialization_matches() {
+    for kind in Kind::iter() {
+        let json_value = serde_json::to_value(kind).expect("serde serialization");
+        let json = json_value.as_str().expect("get string");
+        let strum = kind.to_string();
+
+        assert_eq!(json, strum);
+    }
+}
+
+#[test]
+fn serde_serialization_matches_external_contract() {
+    let mut serialized_strings = vec![
+        "v1.class.jar",
+        "v1.mavencentral.jar",
+        "v1.raw.jar",
+        "comment_stripped:sha_256",
+        "sha_256",
+    ]
+    .into_iter()
+    .collect::<HashSet<&str>>();
+
+    for kind in Kind::iter() {
+        let json_value = serde_json::to_value(kind).expect("serde serialization");
+        let json = json_value.as_str().expect("get string");
+
+        serialized_strings.remove(json);
+    }
+
+    assert_eq!(serialized_strings, HashSet::new());
 }

--- a/tests/it/code_vsi.rs
+++ b/tests/it/code_vsi.rs
@@ -162,8 +162,10 @@ fn serde_serialization_matches_external_contract() {
         let json_value = serde_json::to_value(kind).expect("serde serialization");
         let json = json_value.as_str().expect("get string").to_string();
 
-        // Check that the insert wasn't a duplicate.
-        assert!(actual_serializations_for_kinds.insert(json));
+        assert!(
+            actual_serializations_for_kinds.insert(json),
+            "serialized value for kind {kind:?} is duplicate"
+        );
     }
 
     assert_eq!(


### PR DESCRIPTION
# Overview

The serialization Serde was producing didn't match what we expected it to. This PR adds renames so that our external serialization is correct as well as tests to keep them updated/in-sync.

I bumped the version to 3 since technically this change is breaking I think - even though in reality I'm not sure it actually would.

## Acceptance criteria

* lib-fingerprint outputs the new serialization for fingerprint kinds.

## Testing plan

* Test which checks that every value of the `Kind` enum matches a known good external serialization with no duplicates.
* Test that serde output matches strum.

## Risks

If something else depends on the serde deserialization for `Kind` then that code could break/data could need to be fixed.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
