### PR TITLE
use zip 3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "2.0.12"
 sha2 = "0.10.9"
 hex = { version = "0.4.3", optional = true }
 base64 = { version = "0.22.1", optional = true }
-zip = "4.0.0"
+zip = "3.0.0"
 strum = { version = "0.27.1", features = ["derive"] }
 alphanumeric-sort = "1.5.3"
 tap = "1.0.1"


### PR DESCRIPTION
# Overview

We ran into some dependency conflicts when using lib-fingerprint in a private repo. They were caused by the upgrade of zip to 4.0.0.

This PR downgrades zip to 3.0.0

## Acceptance criteria

- We use zip 3.0.0
- Nothing else changes

## Testing plan

- We will depend on automated tests for this

## Metrics



## Risks


## References



## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
