### PR TITLE
Fix clippy::question_mark error in collapse_handles

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,10 +506,7 @@ fn collapse_handles<T, E>(handles: Vec<ScopedJoinHandle<'_, Result<T, E>>>) -> R
     for handle in handles {
         match handle.join() {
             Err(err) => std::panic::resume_unwind(err),
-            Ok(operation) => match operation {
-                Ok(inner) => collected.push(inner),
-                Err(err) => return Err(err),
-            },
+            Ok(operation) => collected.push(operation?),
         }
     }
     Ok(collected)


### PR DESCRIPTION
# Overview

Clippy 1.97 extended the `question_mark` lint to cover nested `match` expressions, where it previously only caught `if let`. This is causing static checks to fail in CI.

The fix is this:

```rust
// before
Ok(operation) => match operation {
    Ok(inner) => collected.push(inner),
    Err(err) => return Err(err),
},

// after
Ok(operation) => collected.push(operation?),
```

Behavior is unchanged. `?` returns the error early exactly as `return Err(err)` did, and because the function is generic over `E` with no conversion, the blanket `From<E> for E` impl means `?` does not transform the error. The panic path (`resume_unwind`) is untouched.

## Acceptance criteria

- `check-static` passes on this PR, and on other open PRs once this merges.
- No user-visible change. `collapse_handles` returns the same values and errors it did before.

## Testing plan

We just need CI to pass
## Metrics

None needed. CI going green is the signal.

## Risks

Low. It is a one-line change in a private helper, with no behavior change and the full test suite green.

## References

- Found while reviewing #35, where this failure was masking an otherwise clean dependabot bump.
- [clippy::question_mark](https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#question_mark)

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).

No new test. The change has no behavioral difference to assert on — the existing suite covers `collapse_handles` through its callers, and clippy itself is the check that would catch a regression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
